### PR TITLE
Support Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0",
-        "illuminate/console": "^6.0 || ^7.0 || ^8.0",
-        "illuminate/config": "^6.0 || ^7.0 || ^8.0",
-        "symfony/process": "^4.3"
+        "php": ">=8.1",
+        "illuminate/support": "^9.0",
+        "illuminate/console": "^9.0",
+        "illuminate/config": "^9.0",
+        "symfony/process": "^6.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^6.0",


### PR DESCRIPTION
I wasn't able to install in Laravel 9, no way to build compatible package.

I did a fork, changed the requriments for PHP, Illuminate packages and Symfony process. Then I tested by adding to composer.json:

```json
"repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/Shelob9/Backup"
        }
    ]
```

and  in require:

```json
        "cornford/backup": "dev-patch-1"
```

I was able to get the package installed with `composer update`.